### PR TITLE
add hyperHTML.wire to matched patterns

### DIFF
--- a/syntaxes/literally-html.json
+++ b/syntaxes/literally-html.json
@@ -15,7 +15,7 @@
 		{
 			"name": "string.js.taggedTemplate",
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)\\.*\\b(adopt|bind|bound|hyper|hyperHTML|html|raw|render|view|wire)\\b(?:\\([^\\)]*?\\))?(`)",
+			"begin": "(?x)\\.*\\b(hyperHTML\\.wire|adopt|bind|bound|hyper|hyperHTML|html|raw|render|view|wire)\\b(?:\\([^\\)]*?\\))?(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"

--- a/syntaxes/literally-html.json
+++ b/syntaxes/literally-html.json
@@ -15,7 +15,7 @@
 		{
 			"name": "string.js.taggedTemplate",
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)\\.*\\b(hyperHTML\\.wire|adopt|bind|bound|hyper|hyperHTML|html|raw|render|view|wire)\\b(?:\\([^\\)]*?\\))?(`)",
+			"begin": "(?x)\\.*\\b(hyperHTML\\.[A-za-z]*|adopt|bind|bound|hyper|hyperHTML|html|raw|render|view|wire)\\b(?:\\([^\\)]*?\\))?(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"

--- a/syntaxes/literally-html.json
+++ b/syntaxes/literally-html.json
@@ -15,7 +15,7 @@
 		{
 			"name": "string.js.taggedTemplate",
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)\\.*\\b(hyperHTML\\.[A-za-z]*|adopt|bind|bound|hyper|hyperHTML|html|raw|render|view|wire)\\b(?:\\([^\\)]*?\\))?(`)",
+			"begin": "(?x)\\.*\\b(hyperHTML\\.[A-Za-z]*|adopt|bind|bound|hyper|hyperHTML|html|raw|render|view|wire)\\b(?:\\([^\\)]*?\\))?(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
I don't know the first thing about VSCode extensions and I just reverse engineered this to get it to do what I want, so feel free to reject if you know a better way of doing this.

Using `hyperHTML()` and `wire()` work fine for me but `hyperHTML.wire()` messes up the syntax highlighting in the rest of the file. Adding `hyperHTML.wire` to the matched patterns fixes that.

### wire()`` with current version 👍

<img width="236" alt="screen shot 2018-02-26 at 9 48 26" src="https://user-images.githubusercontent.com/1243814/36649574-96694dae-1ae1-11e8-98b7-4462349de672.png">

### hyperHTML.wire()`` with current version 👎

`async` should be blue

<img width="288" alt="screen shot 2018-02-26 at 9 48 36" src="https://user-images.githubusercontent.com/1243814/36649600-d24eb476-1ae1-11e8-9830-c8dd7d6cd6e7.png">


### hyperHTML.wire()`` with updated patterns 👍

<img width="377" alt="screen shot 2018-02-26 at 10 40 25" src="https://user-images.githubusercontent.com/1243814/36649604-dd6bf8be-1ae1-11e8-889c-fd6bde1ab19b.png">

