### PR TITLE
fix: Fix syntax higlighting for unquoted attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
                     "source.tsx",
                     "text.html.basic"
                 ],
-                "scopeName": "inline.lit-html.quoted.string.injection",
-                "path": "./syntaxes/literally-html-quoted-string-injection.json",
+                "scopeName": "inline.lit-html.string.injection",
+                "path": "./syntaxes/literally-html-string-injection.json",
                 "embeddedLanguages": {
                     "meta.template.expression.ts": "typescript"
                 }

--- a/syntaxes/literally-html-string-injection.json
+++ b/syntaxes/literally-html-string-injection.json
@@ -1,6 +1,6 @@
 {
 	"fileTypes": [],
-	"injectionSelector": "L:source.js (string.quoted.double.html, string.quoted.single.html), L:source.jsx (string.quoted.double.html, string.quoted.single.html), L:source.js.jsx (string.quoted.double.html, string.quoted.single.html), L:source.ts (string.quoted.double.html, string.quoted.single.html), L:source.tsx (string.quoted.double.html, string.quoted.single.html)",
+	"injectionSelector": "L:meta.embedded.block.html meta.tag",
 	"patterns": [
 		{
 			"include": "source.ts#template-substitution-element"

--- a/syntaxes/literally-html-string-injection.json
+++ b/syntaxes/literally-html-string-injection.json
@@ -6,5 +6,5 @@
 			"include": "source.ts#template-substitution-element"
 		}
 	],
-	"scopeName": "inline.lit-html.quoted.string.injection"
+	"scopeName": "inline.lit-html.string.injection"
 }


### PR DESCRIPTION
This ports https://github.com/mjbvz/vscode-lit-html/pull/57 to literally&#x2011;html.

**Note:** Split across two commits to preserve <code>git&nbsp;blame</code>.

---

review?(@WebReflection)