### PR TITLE
feat: Add support for `lighterhtml.node`

### DIFF
--- a/syntaxes/literally-html.json
+++ b/syntaxes/literally-html.json
@@ -15,7 +15,7 @@
 		{
 			"name": "string.js.taggedTemplate",
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)\\.*(?:[a-zA-Z]+\\.)?\\b(adopt|bind|bound|for|hyper|hyperHTML|html|raw|render|svg|view|viper|viperHTML|wire)\\b(?:\\([^\\)]*?\\))?(`)",
+			"begin": "(?x)\\.*(?:[a-zA-Z]+\\.)?\\b(adopt|bind|bound|for|hyper|hyperHTML|html|node|raw|render|svg|view|viper|viperHTML|wire)\\b(?:\\([^\\)]*?\\))?(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
**Lighterhtml**&nbsp;has the&nbsp;`(html|svg).node`&nbsp;function, which&nbsp;allows creating&nbsp;one‑off&nbsp;markup that&nbsp;can&nbsp;be&nbsp;easily appended&nbsp;to&nbsp;other&nbsp;elements, without&nbsp;needing to&nbsp;use&nbsp;the&nbsp;`render(…)`&nbsp;function.